### PR TITLE
Quote variable stunnel_services in with_items

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
   file:
     path: '/etc/stunnel/{{ item.filename | default(item.name) }}.conf'
     state: 'absent'
-  with_items: stunnel_services
+  with_items: "{{ stunnel_services }}"
   when: ((item.name is defined and item.name) and
          (item.delete is defined and item.delete | bool))
   notify: [ 'Restart stunnel' ]
@@ -40,7 +40,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  with_items: stunnel_services
+  with_items: "{{ stunnel_services }}"
   when: ((item.name is defined and item.name) and
          (item.delete is undefined or not item.delete | bool))
   notify: [ 'Restart stunnel' ]


### PR DESCRIPTION
Without quotes the items of `stunnel_services` were not taken up, resulting in config files not being written. With the patch things work with ansible 2.4.0.